### PR TITLE
only if gradient is on, then will set gradientId and gradientFill, ot…

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar.component.ts
@@ -60,8 +60,8 @@ export class BarComponent implements OnChanges {
 
   element: any;
   path: any;
-  gradientId: any;
-  gradientFill: any;
+  gradientId = '';
+  gradientFill = '';
   startOpacity: any;
   gradientStops: any[];
   hasGradient: boolean = false;
@@ -79,10 +79,10 @@ export class BarComponent implements OnChanges {
   }
 
   update(): void {
-    this.gradientId = 'grad' + id().toString();
-    this.gradientFill = `url(#${this.gradientId})`;
 
     if (this.gradient || this.stops) {
+      this.gradientId = 'grad' + id().toString();
+      this.gradientFill = `url(#${this.gradientId})`;
       this.gradientStops = this.getGradient();
       this.hasGradient = true;
     } else {


### PR DESCRIPTION
only if gradient is on, then will set gradientId and gradientFill, otherwise, if there are many bar components, that will cause max call size issue

**What kind of change does this PR introduce?** (check one with "x")
- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
 if there are many bar components, that will cause max call size issue

**What is the new behavior?**
only if gradient is on, then will set gradientId and gradientFill, avoid generate too much unused id


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
